### PR TITLE
Update homepage chapters and branding

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,9 +14,9 @@ import './globals.css'
 const inter = Inter({ subsets: ['latin'] })
 
 const metadata: Metadata = {
-    title: 'Triết Talk - Khám phá thế giới triết học',
+    title: 'E-Learning - Khám phá thế giới triết học',
     description:
-        'Blog triết học với nội dung đa ngôn ngữ, quiz tương tác và AI assistant',
+        'Nền tảng E-Learning triết học với bài viết song ngữ, quiz tương tác và AI assistant',
     generator: 'v0.dev',
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,8 +10,6 @@ import {
     Brain,
     Globe,
     Sparkles,
-    TrendingUp,
-    Video,
 } from 'lucide-react'
 import Link from 'next/link'
 
@@ -32,6 +30,86 @@ const blogs = Object.values(blogData)
 
 export default function HomePage() {
     const { t } = useLanguage()
+
+    const chapterArticleCounts = Object.values(blogData).reduce<
+        Record<string, number>
+    >((acc, blog) => {
+        const segments = blog.section.split('.')
+        const chapterId = segments.slice(0, 2).join('.') || blog.section
+        acc[chapterId] = (acc[chapterId] || 0) + 1
+        return acc
+    }, {})
+
+    const chapterCards = [
+        {
+            id: '4.1',
+            href: '/blogs?blog=4.1',
+            title: t('home.chapter41Title'),
+            description: t('home.chapter41Description'),
+            icon: BookOpen,
+            gradient:
+                'from-purple-50 via-blue-50 to-indigo-50 dark:from-purple-900/20 dark:via-blue-900/20 dark:to-indigo-900/20',
+            border: 'border-purple-200/50 dark:border-purple-700/50',
+            floatingTop: 'from-purple-500/20 to-blue-500/20',
+            floatingBottom: 'from-indigo-500/15 to-purple-500/15',
+            iconGradient: 'from-purple-500 to-blue-600',
+            statsBg: 'bg-purple-100 dark:bg-purple-900/50',
+            statsText: 'text-purple-700 dark:text-purple-300',
+            titleHover:
+                'group-hover:text-purple-600 dark:group-hover:text-purple-400',
+            buttonHover:
+                'group-hover:bg-gradient-to-r group-hover:from-purple-500 group-hover:to-blue-600 group-hover:text-white group-hover:border-transparent',
+            buttonClasses:
+                'border-2 border-purple-200 text-purple-700 hover:text-white dark:border-purple-500 dark:text-purple-300',
+            shadow:
+                'hover:shadow-purple-500/25 dark:hover:shadow-purple-400/25',
+        },
+        {
+            id: '4.2',
+            href: '/blogs?blog=4.2',
+            title: t('home.chapter42Title'),
+            description: t('home.chapter42Description'),
+            icon: Globe,
+            gradient:
+                'from-emerald-50 via-green-50 to-teal-50 dark:from-emerald-900/20 dark:via-green-900/20 dark:to-teal-900/20',
+            border: 'border-emerald-200/50 dark:border-emerald-700/50',
+            floatingTop: 'from-emerald-500/20 to-teal-500/20',
+            floatingBottom: 'from-green-500/15 to-emerald-500/15',
+            iconGradient: 'from-emerald-500 to-teal-600',
+            statsBg: 'bg-emerald-100 dark:bg-emerald-900/50',
+            statsText: 'text-emerald-700 dark:text-emerald-300',
+            titleHover:
+                'group-hover:text-emerald-600 dark:group-hover:text-emerald-400',
+            buttonHover:
+                'group-hover:bg-gradient-to-r group-hover:from-emerald-500 group-hover:to-teal-600 group-hover:text-white group-hover:border-transparent',
+            buttonClasses:
+                'border-2 border-emerald-200 text-emerald-700 hover:text-white dark:border-emerald-500 dark:text-emerald-300',
+            shadow:
+                'hover:shadow-emerald-500/25 dark:hover:shadow-emerald-400/25',
+        },
+        {
+            id: '4.3',
+            href: '/blogs?blog=4.3',
+            title: t('home.chapter43Title'),
+            description: t('home.chapter43Description'),
+            icon: Sparkles,
+            gradient:
+                'from-rose-50 via-orange-50 to-yellow-50 dark:from-rose-900/20 dark:via-orange-900/20 dark:to-yellow-900/20',
+            border: 'border-rose-200/50 dark:border-rose-700/50',
+            floatingTop: 'from-rose-500/20 to-orange-500/20',
+            floatingBottom: 'from-yellow-500/15 to-rose-500/15',
+            iconGradient: 'from-rose-500 to-orange-500',
+            statsBg: 'bg-rose-100 dark:bg-rose-900/50',
+            statsText: 'text-rose-700 dark:text-rose-300',
+            titleHover:
+                'group-hover:text-rose-600 dark:group-hover:text-rose-400',
+            buttonHover:
+                'group-hover:bg-gradient-to-r group-hover:from-rose-500 group-hover:to-orange-500 group-hover:text-white group-hover:border-transparent',
+            buttonClasses:
+                'border-2 border-rose-200 text-rose-700 hover:text-white dark:border-rose-500 dark:text-rose-300',
+            shadow: 'hover:shadow-rose-500/25 dark:hover:shadow-rose-400/25',
+        },
+    ] as const
 
     return (
         <div className="container mx-auto px-4 py-8">
@@ -84,20 +162,9 @@ export default function HomePage() {
                             className="text-lg px-8 py-3 border-2 border-emerald-500 text-emerald-600 hover:bg-emerald-500 hover:text-white dark:border-emerald-400 dark:text-emerald-400 dark:hover:bg-emerald-400 dark:hover:text-gray-900 transform hover:scale-105 transition-all duration-300"
                             asChild
                         >
-                            <Link href="/videos">
-                                <Video className="mr-2 h-5 w-5" />
-                                {t('home.watchVideos')}
-                            </Link>
-                        </Button>
-                        <Button
-                            variant="secondary"
-                            size="lg"
-                            className="text-lg px-8 py-3 bg-gradient-to-r from-pink-500 to-rose-500 hover:from-pink-600 hover:to-rose-600 text-white dark:from-pink-400 dark:to-rose-400 dark:hover:from-pink-500 dark:hover:to-rose-500 transform hover:scale-105 transition-all duration-300"
-                            asChild
-                        >
                             <Link href="/quiz">
-                                <Sparkles className="mr-2 h-5 w-5" />
-                                {t('home.exploreNow')}
+                                <Brain className="mr-2 h-5 w-5" />
+                                {t('home.takeQuiz')}
                             </Link>
                         </Button>
                     </div>
@@ -128,76 +195,57 @@ export default function HomePage() {
                     </h2>
                 </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                    {/* Enhanced Blog 2 Card */}
-                    <div className="group relative overflow-hidden rounded-3xl bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-50 dark:from-purple-900/20 dark:via-blue-900/20 dark:to-indigo-900/20 p-8 border border-purple-200/50 dark:border-purple-700/50 hover:shadow-2xl hover:shadow-purple-500/25 dark:hover:shadow-purple-400/25 transition-all duration-500 hover:-translate-y-2 animate-fade-in-left">
-                        <div className="absolute top-0 right-0 w-40 h-40 bg-gradient-to-br from-purple-500/20 to-blue-500/20 rounded-full -translate-y-20 translate-x-20 group-hover:scale-150 group-hover:rotate-45 transition-all duration-700"></div>
-                        <div className="absolute bottom-0 left-0 w-32 h-32 bg-gradient-to-tr from-indigo-500/15 to-purple-500/15 rounded-full translate-y-16 -translate-x-16 group-hover:scale-125 group-hover:-rotate-45 transition-all duration-700"></div>
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
+                    {chapterCards.map((card, index) => {
+                        const Icon = card.icon
+                        const articleCount = chapterArticleCounts[card.id] || 0
 
-                        <div className="relative z-10">
-                            <div className="w-16 h-16 bg-gradient-to-br from-purple-500 to-blue-600 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 group-hover:rotate-12 transition-all duration-300 shadow-lg">
-                                <BookOpen className="h-8 w-8 text-white" />
-                            </div>
-                            <h3 className="text-2xl font-bold mb-3 text-gray-900 dark:text-gray-100 group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors duration-300">
-                                {t('home.blog2Title')}
-                            </h3>
-                            <p className="text-muted-foreground mb-6 leading-relaxed">
-                                {t('home.blog2Description')}
-                            </p>
-                            <div className="flex items-center justify-between">
-                                <Button
-                                    asChild
-                                    variant="outline"
-                                    className="group-hover:bg-gradient-to-r group-hover:from-purple-500 group-hover:to-blue-600 group-hover:text-white group-hover:border-transparent transition-all duration-300 hover:scale-105"
-                                >
-                                    <Link href="/blogs?blog=2.1">
-                                        {t('home.explore')}{' '}
-                                        <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform duration-300" />
-                                    </Link>
-                                </Button>
-                                <div className="px-3 py-1 bg-purple-100 dark:bg-purple-900/50 rounded-full">
-                                    <span className="text-sm font-medium text-purple-700 dark:text-purple-300">
-                                        6 {t('home.articles')}
-                                    </span>
+                        return (
+                            <div
+                                key={card.id}
+                                className={`group relative overflow-hidden rounded-3xl bg-gradient-to-br ${card.gradient} p-8 border ${card.border} ${card.shadow} transition-all duration-500 hover:-translate-y-2 animate-fade-in-up`}
+                                style={{ animationDelay: `${index * 150}ms` }}
+                            >
+                                <div
+                                    className={`absolute top-0 right-0 w-40 h-40 bg-gradient-to-br ${card.floatingTop} rounded-full -translate-y-20 translate-x-20 group-hover:scale-150 group-hover:rotate-45 transition-all duration-700`}
+                                ></div>
+                                <div
+                                    className={`absolute bottom-0 left-0 w-32 h-32 bg-gradient-to-tr ${card.floatingBottom} rounded-full translate-y-16 -translate-x-16 group-hover:scale-125 group-hover:-rotate-45 transition-all duration-700`}
+                                ></div>
+
+                                <div className="relative z-10">
+                                    <div className={`w-16 h-16 bg-gradient-to-br ${card.iconGradient} rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 group-hover:rotate-12 transition-all duration-300 shadow-lg`}>
+                                        <Icon className="h-8 w-8 text-white" />
+                                    </div>
+                                    <h3
+                                        className={`text-2xl font-bold mb-3 text-gray-900 dark:text-gray-100 transition-colors duration-300 ${card.titleHover}`}
+                                    >
+                                        {card.title}
+                                    </h3>
+                                    <p className="text-muted-foreground mb-6 leading-relaxed">
+                                        {card.description}
+                                    </p>
+                                    <div className="flex items-center justify-between">
+                                        <Button
+                                            asChild
+                                            variant="outline"
+                                            className={`${card.buttonHover} ${card.buttonClasses} transition-all duration-300 hover:scale-105`}
+                                        >
+                                            <Link href={card.href}>
+                                                {t('home.explore')}{' '}
+                                                <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform duration-300" />
+                                            </Link>
+                                        </Button>
+                                        <div className={`px-3 py-1 rounded-full ${card.statsBg}`}>
+                                            <span className={`text-sm font-medium ${card.statsText}`}>
+                                                {articleCount} {t('home.articles')}
+                                            </span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-
-                    {/* Enhanced Blog 3 Card */}
-                    <div className="group relative overflow-hidden rounded-3xl bg-gradient-to-br from-emerald-50 via-green-50 to-teal-50 dark:from-emerald-900/20 dark:via-green-900/20 dark:to-teal-900/20 p-8 border border-emerald-200/50 dark:border-emerald-700/50 hover:shadow-2xl hover:shadow-emerald-500/25 dark:hover:shadow-emerald-400/25 transition-all duration-500 hover:-translate-y-2 animate-fade-in-right">
-                        <div className="absolute top-0 right-0 w-40 h-40 bg-gradient-to-br from-emerald-500/20 to-teal-500/20 rounded-full -translate-y-20 translate-x-20 group-hover:scale-150 group-hover:rotate-45 transition-all duration-700"></div>
-                        <div className="absolute bottom-0 left-0 w-32 h-32 bg-gradient-to-tr from-green-500/15 to-emerald-500/15 rounded-full translate-y-16 -translate-x-16 group-hover:scale-125 group-hover:-rotate-45 transition-all duration-700"></div>
-
-                        <div className="relative z-10">
-                            <div className="w-16 h-16 bg-gradient-to-br from-emerald-500 to-teal-600 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 group-hover:rotate-12 transition-all duration-300 shadow-lg">
-                                <TrendingUp className="h-8 w-8 text-white" />
-                            </div>
-                            <h3 className="text-2xl font-bold mb-3 text-gray-900 dark:text-gray-100 group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors duration-300">
-                                {t('home.blog3Title')}
-                            </h3>
-                            <p className="text-muted-foreground mb-6 leading-relaxed">
-                                {t('home.blog3Description')}
-                            </p>
-                            <div className="flex items-center justify-between">
-                                <Button
-                                    asChild
-                                    variant="outline"
-                                    className="group-hover:bg-gradient-to-r group-hover:from-emerald-500 group-hover:to-teal-600 group-hover:text-white group-hover:border-transparent transition-all duration-300 hover:scale-105"
-                                >
-                                    <Link href="/blogs?blog=3.1">
-                                        {t('home.explore')}{' '}
-                                        <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform duration-300" />
-                                    </Link>
-                                </Button>
-                                <div className="px-3 py-1 bg-emerald-100 dark:bg-emerald-900/50 rounded-full">
-                                    <span className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
-                                        6 {t('home.articles')}
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                        )
+                    })}
                 </div>
             </section>
 

--- a/components/chat-bubble.tsx
+++ b/components/chat-bubble.tsx
@@ -37,7 +37,7 @@ export function ChatBubble() {
   // Khởi tạo tin nhắn chào mừng khi mở chat
   useEffect(() => {
     if (isOpen && messages.length === 0) {
-      const welcomeMessageText = "Triết Talk xin chào! Bạn muốn thảo luận về chủ đề triết học nào?";
+      const welcomeMessageText = "E-Learning xin chào! Bạn muốn thảo luận về chủ đề triết học nào?";
       geminiApiClient.resetChatHistory();
       setMessages([
         {
@@ -136,7 +136,7 @@ const handleSendMessage = async () => {
           <Card className="w-full max-w-2xl h-[70vh] flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-lg">
-                {t ? t('chat.title') : 'Triết Talk'}
+                {t ? t('chat.title') : 'E-Learning'}
               </CardTitle>
               <Button
                 variant="ghost"
@@ -186,7 +186,7 @@ const handleSendMessage = async () => {
                   value={inputValue}
                   onChange={(e) => setInputValue(e.target.value)}
                   onKeyPress={handleKeyPress}
-                  placeholder={t ? t('chat.placeholder') : 'Trò chuyện cùng Triết Talk...'}
+                  placeholder={t ? t('chat.placeholder') : 'Trò chuyện cùng E-Learning...'}
                   className="flex-1"
                   disabled={isBotReplying}
                 />

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -6,10 +6,10 @@ import { BookOpen, Github, Mail, Twitter } from 'lucide-react'
 import Link from 'next/link'
 
 export function Footer() {
-    const { t, currentLanguage, getLocalizedContent } = useLanguage()
+    const { t, getLocalizedContent } = useLanguage()
 
     // Get available blogs dynamically
-    const availableBlogs = Object.entries(philosophyBlogs).slice(0, 4) // Show first 4 blogs
+    const availableBlogs = Object.entries(philosophyBlogs)
 
     return (
         <footer className="bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 border-t mt-16">
@@ -63,12 +63,6 @@ export function Footer() {
                                 📚 {t('nav.blog')}
                             </Link>
                             <Link
-                                href="/videos"
-                                className="block text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 text-sm transition-colors duration-200 hover:translate-x-1 transform"
-                            >
-                                🎥 {t('nav.videos')}
-                            </Link>
-                            <Link
                                 href="/quiz"
                                 className="block text-muted-foreground hover:text-emerald-600 dark:hover:text-emerald-400 text-sm transition-colors duration-200 hover:translate-x-1 transform"
                             >
@@ -89,18 +83,18 @@ export function Footer() {
                             {t('footer.blogs')}
                         </h3>
                         <div className="space-y-3">
-                            <Link
-                                href="/blogs?blog=2.1"
-                                className="block text-muted-foreground hover:text-purple-600 dark:hover:text-purple-400 text-sm transition-colors duration-200 hover:translate-x-1 transform"
-                            >
-                                {t('footer.blog2')}
-                            </Link>
-                            <Link
-                                href="/blogs?blog=3.1"
-                                className="block text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 text-sm transition-colors duration-200 hover:translate-x-1 transform"
-                            >
-                                {t('footer.blog3')}
-                            </Link>
+                            {availableBlogs.map(([blogId, blog]) => {
+                                const blogTitle = getLocalizedContent(blog.title)
+                                return (
+                                    <Link
+                                        key={blogId}
+                                        href={`/blogs?blog=${blogId}`}
+                                        className="block text-muted-foreground hover:text-purple-600 dark:hover:text-purple-400 text-sm transition-colors duration-200 hover:translate-x-1 transform"
+                                    >
+                                        {blogTitle}
+                                    </Link>
+                                )
+                            })}
                             <Link
                                 href="/blogs"
                                 className="block text-muted-foreground hover:text-emerald-600 dark:hover:text-emerald-400 text-sm transition-colors duration-200 hover:translate-x-1 transform"

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -6,7 +6,7 @@ import { ThemeToggle } from '@/components/theme-toggle'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
 import { useLanguage } from '@/contexts/language-context'
-import { BookOpen, Home, Menu, MessageSquare, Video } from 'lucide-react'
+import { BookOpen, Brain, Home, Menu, MessageSquare } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 
@@ -17,7 +17,7 @@ export function Navigation() {
     const navItems = [
         { href: '/', label: t('nav.home'), icon: Home },
         { href: '/blogs', label: t('nav.blog'), icon: BookOpen },
-        { href: '/videos', label: t('nav.videos'), icon: Video },
+        { href: '/quiz', label: t('nav.quiz'), icon: Brain },
         { href: '/feedback', label: t('nav.feedback'), icon: MessageSquare },
     ]
 

--- a/components/ui/typing-indicator.tsx
+++ b/components/ui/typing-indicator.tsx
@@ -5,7 +5,7 @@ export function TypingIndicator() {
     <div className="flex items-center justify-center p-2">
       {/* 👇 [SỬA ĐỔI] Dải màu rộng hơn và background to hơn để chuyển động mượt hơn */}
       <p className="animate-text-gradient bg-gradient-to-r from-purple-500 via-pink-500 via-red-500 via-orange-400 via-yellow-500 via-green-400 via-teal-400 via-blue-500 to-indigo-500 bg-[400%_auto] bg-clip-text text-transparent">
-        Triết Talk đang suy ngẫm...
+        E-Learning đang suy ngẫm...
       </p>
     </div>
   );

--- a/data/translations.ts
+++ b/data/translations.ts
@@ -2,7 +2,7 @@ export const translations = {
   nav: {
     home: { vietnamese: 'Trang chủ', english: 'Home' },
     blog: { vietnamese: 'Chương', english: 'Chapters' },
-    videos: { vietnamese: 'Video', english: 'Videos' },
+    quiz: { vietnamese: 'Quiz', english: 'Quiz' },
     feedback: { vietnamese: 'Phản hồi', english: 'Feedback' },
     theme: { vietnamese: 'Giao diện', english: 'Theme' },
   },
@@ -12,7 +12,7 @@ export const translations = {
       vietnamese: 'Khám phá các chương triết học',
       english: 'Explore philosophy chapters',
     },
-    title: { vietnamese: 'Triết Talk', english: 'Triết Talk' },
+    title: { vietnamese: 'E-Learning', english: 'E-Learning' },
     subtitle: {
       vietnamese: 'Khám phá thế giới triết học qua những bài viết sâu sắc và tương tác',
       english: 'Explore the world of philosophy through in-depth and interactive articles',
@@ -22,8 +22,7 @@ export const translations = {
       english: 'Marxist philosophy learning platform with an AI assistant, interactive quizzes, and bilingual content',
     },
     readBlog: { vietnamese: 'Nội dung', english: 'Contents' },
-    watchVideos: { vietnamese: 'Xem video', english: 'Watch videos' },
-    exploreNow: { vietnamese: 'Ôn bài ngay', english: 'Revise now' },
+    takeQuiz: { vietnamese: 'Làm quiz', english: 'Take quiz' },
     articlesCount: { vietnamese: 'Bài viết triết học', english: 'Philosophy articles' },
     languagesSupported: { vietnamese: 'Ngôn ngữ hỗ trợ', english: 'Languages supported' },
     quizQuestions: { vietnamese: 'Câu hỏi quiz', english: 'Quiz questions' },
@@ -36,29 +35,29 @@ export const translations = {
     weeklyUpdates: { vietnamese: 'Được cập nhật hàng tuần', english: 'Updated weekly' },
     languageSupport: { vietnamese: 'Vi, En', english: 'Vi, En' },
     interactiveQuiz: { vietnamese: 'Quiz tương tác', english: 'Interactive quiz' },
-    blog2Title: {
-      vietnamese: 'Chương 2: Hàng hóa & Thị trường',
-      english: 'Chapter 2: Commodities & Markets',
+    chapter41Title: {
+      vietnamese: 'Chương 4.1: Dân chủ và dân chủ xã hội chủ nghĩa',
+      english: 'Chapter 4.1: Democracy & Socialist Democracy',
     },
-    blog2Description: {
-      vietnamese: 'Khám phá hàng hóa, lao động sản xuất và kinh tế thị trường trong tư tưởng Marx',
-      english: 'Explore commodities, productive labour, and the market economy in Marxist thought',
+    chapter41Description: {
+      vietnamese: 'Tìm hiểu nguồn gốc, bản chất và giá trị của nền dân chủ xã hội chủ nghĩa.',
+      english: 'Discover the origins, nature, and values of socialist democracy.',
     },
-    blog3Title: {
-      vietnamese: 'Chương 3: Tư bản & Giá trị thặng dư',
-      english: 'Chapter 3: Capital & Surplus Value',
+    chapter42Title: {
+      vietnamese: 'Chương 4.2: Nhà nước xã hội chủ nghĩa',
+      english: 'Chapter 4.2: The Socialist State',
     },
-    blog3Description: {
-      vietnamese: 'Tìm hiểu về tư bản, quá trình sản xuất và phân phối giá trị thặng dư',
-      english: 'Learn about capital, the production process, and surplus value distribution',
+    chapter42Description: {
+      vietnamese: 'Khám phá cấu trúc, chức năng và vai trò lịch sử của nhà nước xã hội chủ nghĩa.',
+      english: 'Explore the structure, functions, and historical role of the socialist state.',
     },
-    blog4Title: {
-      vietnamese: 'Chương 4: Dân chủ & Nhà nước XHCN',
-      english: 'Chapter 4: Socialist Democracy & State',
+    chapter43Title: {
+      vietnamese: 'Chương 4.3: Dân chủ XHCN & Nhà nước pháp quyền ở Việt Nam',
+      english: 'Chapter 4.3: Socialist Democracy & Rule-of-Law State in Vietnam',
     },
-    blog4Description: {
-      vietnamese: 'Dân chủ XHCN, Nhà nước XHCN và thực tiễn ở Việt Nam',
-      english: 'Socialist democracy, the socialist state, and Vietnam’s practice',
+    chapter43Description: {
+      vietnamese: 'Liên hệ thực tiễn Việt Nam trong xây dựng dân chủ và nhà nước pháp quyền XHCN.',
+      english: 'Connect Vietnam’s practice in building socialist democracy and a rule-of-law state.',
     },
     explore: { vietnamese: 'Khám phá', english: 'Explore' },
     articles: { vietnamese: 'bài viết', english: 'articles' },
@@ -326,13 +325,11 @@ export const translations = {
 
   footer: {
     description: {
-      vietnamese: 'Khám phá triết học qua các bài viết sâu sắc, quiz tương tác và trợ lý AI thông minh.',
-      english: 'Explore philosophy through thoughtful articles, interactive quizzes, and a smart AI assistant.',
+      vietnamese: 'Nền tảng E-Learning triết học với bài viết song ngữ, quiz tương tác và trợ lý AI thông minh.',
+      english: 'A philosophy E-Learning hub with bilingual articles, interactive quizzes, and an intelligent AI assistant.',
     },
     quickLinks: { vietnamese: 'Liên kết nhanh', english: 'Quick links' },
     blogs: { vietnamese: 'Các chương', english: 'Chapters' },
-    blog2: { vietnamese: 'Chương 2: Hàng hóa & Thị trường', english: 'Chapter 2: Commodities & Markets' },
-    blog3: { vietnamese: 'Chương 3: Tư bản & Giá trị thặng dư', english: 'Chapter 3: Capital & Surplus Value' },
     allArticles: { vietnamese: 'Toàn bộ bài viết', english: 'All articles' },
     practiceQuiz: { vietnamese: 'Luyện quiz', english: 'Practice quizzes' },
     resourcesTools: { vietnamese: 'Tài nguyên & công cụ', english: 'Resources & tools' },


### PR DESCRIPTION
## Summary
- replace the home page chapter highlights with three Chapter 4 cards that link to the corresponding blog collections and display dynamic article counts
- refresh visible branding text from “Triết Talk” to “E-Learning” across the navigation, footer, chat widget, and site metadata
- switch navigation and footer quick links from the videos section to the quiz section, keeping the quick links list in sync with the available chapters

## Testing
- npm run lint *(fails to run non-interactively because Next.js prompts to create a new ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e6d6bbf48328b6c8a996830c01f2